### PR TITLE
Separate autocompletion data from the main code

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,13 +40,13 @@ $(function() {
     eof: function() {
     }
   });
-  
+
   var editor = ace.edit(editorElement[0]);
   editor.setTheme("ace/theme/twilight");
 
   var GherkinMode = require("ace/mode/gherkin").Mode;
   editor.getSession().setMode(new GherkinMode());
-  
+
   var Search = require("ace/search").Search;
 
   editor.getSession().setTabSize(2);
@@ -55,7 +55,7 @@ $(function() {
   editor.getSession().on('change', function(e) {
     somethingChanged = true;
   });
-  
+
   // we can not use "on change" for autocompletion directly, because when
   // pressing enter, the cursore is moved after the onChange event, so that
   // in the time on change is invoked, we are still on the old line.
@@ -77,14 +77,6 @@ $(function() {
 
   // Code completion
 
-  // sample step definitions, to be loaded from external sources
-  var stepDefinitions = {
-    '^I am in a ([^"]*)$' : ['I am in a browser', 'I am in a bar'],
-    '^I make a syntax error$' : [],
-    '^stuff should be red$' : []
-  };
-
-  var autocomplete = new Autocomplete(stepDefinitions);
 
   var replaceCurrentStep = function (value) {
     // select current line
@@ -104,16 +96,19 @@ $(function() {
   };
 
   $( "#autocomplete_input" ).autocomplete({
+    autocompleter: undefined,
     source: function (request, response) {
-      var suggestedSteps = autocomplete.suggest(request.term);
-      var suggestedStepNames = [];
-      suggestedSteps.forEach(function (stepDefinition) {
-        suggestedStepNames.push({ label: stepDefinition.step(), value: stepDefinition.step()});
-        stepDefinition.examples.forEach(function (example) {
-          suggestedStepNames.push({ label: '<div class="autocomplete-indent">'+example+'</div>', value: example});
+      if(this.options.autocompleter){
+        var suggestedSteps = this.options.autocompleter.suggest(request.term);
+        var suggestedStepNames = [];
+        suggestedSteps.forEach(function (stepDefinition) {
+          suggestedStepNames.push({ label: stepDefinition.step(), value: stepDefinition.step()});
+          stepDefinition.examples.forEach(function (example) {
+            suggestedStepNames.push({ label: '<div class="autocomplete-indent">'+example+'</div>', value: example});
+          });
         });
-      });
-      response.call(this, suggestedStepNames);
+        response.call(this, suggestedStepNames);
+      }
     },
     select: function (event, ui) {
       replaceCurrentStep(ui.item.value);

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
     <script src="/js/ge/main.js"></script>
     <script src="/js/ge/autocomplete/autocomplete.js"></script>
     <script src="/js/ge/autocomplete/keybinding.js"></script>
+    <script src="/js/autocomplete-sample.js"></script>
   </head>
   <body>
     <input type="text" style="z-index: 0" name="autocomplete" id="autocomplete_input"/>

--- a/public/js/autocomplete-sample.js
+++ b/public/js/autocomplete-sample.js
@@ -1,0 +1,11 @@
+$(function () {
+  // sample step definitions, to be loaded from external sources
+  var stepDefinitions = {
+    '^I am in a ([^"]*)$' : ['I am in a browser', 'I am in a bar'],
+    '^I make a syntax error$' : [],
+    '^stuff should be red$' : []
+  };
+
+  var autocompleter = new Autocomplete(stepDefinitions);
+  $("#autocomplete_input").autocomplete("option","autocompleter", autocompleter);
+});


### PR DESCRIPTION
The data used for autocompletion can be loaded in other scripts. To allow this
we store 'autocompleter' (instance of Autocomplete, I haven't made up better name)
 as an option for autocomplete plugin.

Data for autocompletion are loaded in a separate file
("public/js/autocomplete-sample.js" for the sample).
