### PR TITLE
Fix for loading ace before autocomplete plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ Make a feature branch for everything you do
 * Move autocomplete widget to ace-autocomplete project once it matures? May improve quality long term (more contributors).
 * Fix 404 for jquery-ui png images. Ideally generate jquery-ui css files from current theme.
 * Figure out how require-js works so we don't need to require so many files in our HTML.
+* Separate displaying of autocompleted text from its content - we may
+  want to indent (or use other visual style for) step examples to separate them from step definitions

--- a/public/js/gherkin-editor.js
+++ b/public/js/gherkin-editor.js
@@ -16,14 +16,14 @@
         editor.getSession().setMode(new GherkinMode());
 
         // Use a simple Java Applet for partial matches. Javascript RegExp doesn't know how to do that unfortunately.
-        if(!document.applets('PartialMatch')) {
-          var applet = document.createElement('applet');
-          applet.name = 'PartialMatch';
-          applet.attributes['codebase'] = '/applet';
-          applet.code = 'gherkin.editor.PartialMatch.class';
-          applet.width = '0';
-          applet.height = '0';
-          document.body.appendChild(applet);
+        if(!$('applet[name="PartialMatch"]')[0]) {
+          var PartialMatch = document.createElement('applet');
+          PartialMatch.name = 'PartialMatch';
+          PartialMatch.attributes['codebase'] = '/applet';
+          PartialMatch.code = 'gherkin.editor.PartialMatch.class';
+          PartialMatch.width = '0';
+          PartialMatch.height = '0';
+          document.body.appendChild(PartialMatch);
         }
 
         function matches(text) {

--- a/public/js/gherkin-editor.js
+++ b/public/js/gherkin-editor.js
@@ -28,10 +28,16 @@
 
         function matches(text) {
           var result = [];
-          for(var n in stepdefs) {
-            var stepdef = stepdefs[n].source;
+          for(var stepdef in stepdefs) {
             if(PartialMatch.isPartialMatch(stepdef, text)) {
               result.push(stepdef);
+            }
+            var examples = stepdefs[stepdef];
+            for(var n in examples) {
+              var example = examples[n];
+              if(example.indexOf(text) != -1){
+                result.push(example);
+              }
             }
           }
           return result;

--- a/public/js/gherkin-editor/autocomplete.js
+++ b/public/js/gherkin-editor/autocomplete.js
@@ -12,7 +12,7 @@ define(["pilot/canon","ace/ace"], function(canon) {
     element.style.display = 'none';
     element.style.listStyleType = 'none';
     element.style.padding = '2px';
-    element.style.position = 'absolute';
+    element.style.position = 'fixed';
     element.style.zIndex = '1000';
     editor.container.appendChild(element);
 
@@ -87,7 +87,7 @@ define(["pilot/canon","ace/ace"], function(canon) {
       // Position the list
       var coords = editor.renderer.textToScreenCoordinates(row, column);
       element.style.top = coords.pageY + 2 + 'px';
-      element.style.left = coords.pageX + -2 + 'px';      
+      element.style.left = coords.pageX + -2 + 'px';
       element.style.display = 'block';
 
       // Take over the keyboard

--- a/public/js/gherkin-editor/autocomplete.js
+++ b/public/js/gherkin-editor/autocomplete.js
@@ -49,7 +49,16 @@ define(["pilot/canon","ace/ace"], function(canon) {
     function replace() {
       var Range = require('ace/range').Range;
       var range = new Range(self.row, self.column, self.row, self.column + 1000);
-      editor.session.replace(range, current().innerText);
+      // Firefox does not support innerText property, don't know about IE
+      // http://blog.coderlab.us/2005/09/22/using-the-innertext-property-with-firefox/
+      var selectedValue;
+      if(document.all){
+        selectedValue = current().innerText;
+      } else{
+        selectedValue = current().textContent;
+      }
+
+      editor.session.replace(range, selectedValue);
       // Deactivate asynchrounously, so that in case of ENTER - we don't reactivate immediately.
       setTimeout(function() {
         deactivate();

--- a/public/js/gherkin-editor/autocomplete.js
+++ b/public/js/gherkin-editor/autocomplete.js
@@ -1,4 +1,4 @@
-define(["pilot/canon"], function(canon) {
+define(["pilot/canon","ace/ace"], function(canon) {
   var golinedown = canon.getCommand('golinedown').exec;
   var golineup = canon.getCommand('golineup').exec;
 

--- a/public/js/sample.js
+++ b/public/js/sample.js
@@ -9,11 +9,14 @@ require(['jquery', 'gherkin-editor'], function($) {
 
   $('#editor').gherkinEditor({
     callback: callback,
-    stepdefs: [
-      /I make a syntax error/,
-      /I have (\d+) cukes in my belly/,
-      /I have eaten all the cukes/,
-      /^stuff should be (.*)/
-    ]
+    stepdefs: {
+      'I make a syntax error' : [],
+      'I have (\\d+) cukes in my belly' : [],
+      'I have eaten all the cukes' : [],
+      '^stuff should be (.*)' : 
+				['stuff should be blue',
+				'stuff should be green',
+				'stuff should be red']
+    }
   });
 });


### PR DESCRIPTION
Sometimes autocomplete.js gets loaded before "golinedown" and "golineup"
commands, and the editor is broken. This commit fixes it requiring ace to
be loaded to autocomplete to start working.
